### PR TITLE
Make Reader async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Flavien Raynaud <flavien.raynaud@gmail.com>", "Antonio Verardi <anto
 description = "Library for working with Apache Avro in Rust"
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/flavray/avro-rs"
+repository = "https://github.com/MaterializeInc/avro-rs"
 edition = "2018"
 
 [features]
@@ -17,12 +17,14 @@ crc = { version = "1.3.0", optional = true }
 chrono = { version = "0.4" }
 digest = "0.8"
 failure = "0.1.5"
+futures = "0.3"
 libflate = "0.1"
 log = "0.4.8"
 rand = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snap = { version = "0.2.3", optional = true }
+tokio = { version = "0.2", features = ["io-util"] }
 
 [dev-dependencies]
 md-5 = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snap = { version = "0.2.3", optional = true }
-tokio = { version = "0.2", features = ["io-util"] }
+tokio = { version = "0.2", features = ["io-util", "rt-threaded", "macros"] }
 
 [dev-dependencies]
 md-5 = "0.8"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,4 +1,3 @@
-use futures::executor::block_on;
 use std::time::{Duration, Instant};
 
 use avro_rs::{
@@ -6,6 +5,8 @@ use avro_rs::{
     types::{Record, ToAvro, Value},
     Reader, Writer,
 };
+use futures::executor::block_on;
+use futures::stream::StreamExt;
 
 fn nanos(duration: Duration) -> u64 {
     duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64
@@ -52,18 +53,22 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
     let mut durations = Vec::with_capacity(runs);
 
     for _ in 0..runs {
-        let start = Instant::now();
-        let mut reader = block_on(Reader::with_schema(schema, &bytes[..])).unwrap();
+        let bytes = &bytes[..];
+        let durations = &mut durations;
+        block_on(( || async move {
+            let start = Instant::now();
+            let mut reader = Reader::with_schema(schema, bytes).await.unwrap().into_stream();
 
-        let mut read_records = Vec::with_capacity(count);
-        while let Ok(Some(record)) = block_on(reader.read_next()) {
-            read_records.push(record);
-        }
+            let mut read_records = Vec::with_capacity(count);
+            while let Some(record) = reader.next().await {
+                read_records.push(record);
+            }
 
-        let duration = Instant::now().duration_since(start);
-        durations.push(duration);
+            let duration = Instant::now().duration_since(start);
+            durations.push(duration);
 
-        assert_eq!(count, read_records.len());
+            assert_eq!(count, read_records.len());
+        })());
     }
 
     let total_duration_read = durations.into_iter().fold(0u64, |a, b| a + nanos(b));

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,3 +1,4 @@
+use futures::executor::block_on;
 use std::time::{Duration, Instant};
 
 use avro_rs::{
@@ -52,10 +53,10 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
 
     for _ in 0..runs {
         let start = Instant::now();
-        let reader = Reader::with_schema(schema, &bytes[..]).unwrap();
+        let mut reader = block_on(Reader::with_schema(schema, &bytes[..])).unwrap();
 
         let mut read_records = Vec::with_capacity(count);
-        for record in reader {
+        while let Ok(Some(record)) = block_on(reader.read_next()) {
             read_records.push(record);
         }
 

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -55,7 +55,7 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
     for _ in 0..runs {
         let bytes = &bytes[..];
         let durations = &mut durations;
-        block_on((|| {
+        block_on({
             async move {
                 let start = Instant::now();
                 let mut reader = Reader::with_schema(schema, bytes)
@@ -73,7 +73,7 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
 
                 assert_eq!(count, read_records.len());
             }
-        })());
+        });
     }
 
     let total_duration_read = durations.into_iter().fold(0u64, |a, b| a + nanos(b));

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::io::Read;
 use std::mem::transmute;
 
 use chrono::{NaiveDate, NaiveDateTime};
@@ -8,214 +7,234 @@ use failure::Error;
 use crate::schema::Schema;
 use crate::types::Value;
 use crate::util::{safe_len, zag_i32, zag_i64, DecodeError};
+use futures::future::{BoxFuture, FutureExt};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 #[inline]
-fn decode_long<R: Read>(reader: &mut R) -> Result<Value, Error> {
-    zag_i64(reader).map(Value::Long)
+async fn decode_long<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Value, Error> {
+    zag_i64(reader).await.map(Value::Long)
 }
 
 #[inline]
-fn decode_int<R: Read>(reader: &mut R) -> Result<Value, Error> {
-    zag_i32(reader).map(Value::Int)
+async fn decode_int<R: AsyncRead + Unpin>(reader: &mut R) -> Result<Value, Error> {
+    zag_i32(reader).await.map(Value::Int)
 }
 
 #[inline]
-fn decode_len<R: Read>(reader: &mut R) -> Result<usize, Error> {
-    zag_i64(reader).and_then(|len| safe_len(len as usize))
+async fn decode_len<R: AsyncRead + Unpin>(reader: &mut R) -> Result<usize, Error> {
+    zag_i64(reader).await.and_then(|len| safe_len(len as usize))
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
-pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> {
-    match *schema {
-        Schema::Null => Ok(Value::Null),
-        Schema::Boolean => {
-            let mut buf = [0u8; 1];
-            reader.read_exact(&mut buf[..])?;
+pub fn decode<'a, R: AsyncRead + Unpin + Send>(
+    schema: &'a Schema,
+    reader: &'a mut R,
+) -> BoxFuture<'a, Result<Value, Error>> {
+    async move {
+        match *schema {
+            Schema::Null => Ok(Value::Null),
+            Schema::Boolean => {
+                let mut buf = [0u8; 1];
+                reader.read_exact(&mut buf[..]).await?;
 
-            match buf[0] {
-                0u8 => Ok(Value::Boolean(false)),
-                1u8 => Ok(Value::Boolean(true)),
-                _ => Err(DecodeError::new("not a bool").into()),
+                match buf[0] {
+                    0u8 => Ok(Value::Boolean(false)),
+                    1u8 => Ok(Value::Boolean(true)),
+                    _ => Err(DecodeError::new("not a bool").into()),
+                }
             }
-        }
-        Schema::Int => decode_int(reader),
-        Schema::Long => decode_long(reader),
-        Schema::Float => {
-            let mut buf = [0u8; 4];
-            reader.read_exact(&mut buf[..])?;
-            Ok(Value::Float(unsafe { transmute::<[u8; 4], f32>(buf) }))
-        }
-        Schema::Double => {
-            let mut buf = [0u8; 8];
-            reader.read_exact(&mut buf[..])?;
-            Ok(Value::Double(unsafe { transmute::<[u8; 8], f64>(buf) }))
-        }
-        Schema::Date => match decode_int(reader)? {
-            Value::Int(days) => Ok(Value::Date(
-                NaiveDate::from_ymd(1970, 1, 1)
-                    .checked_add_signed(chrono::Duration::days(days.into()))
-                    .ok_or_else(|| {
-                        DecodeError::new(format!("Invalid num days from epoch: {0}", days))
-                    })?,
-            )),
-            other => {
-                Err(DecodeError::new(format!("Not an Int32 input for Date: {:?}", other)).into())
+            Schema::Int => decode_int(reader).await,
+            Schema::Long => decode_long(reader).await,
+            Schema::Float => {
+                let mut buf = [0u8; 4];
+                reader.read_exact(&mut buf[..]).await?;
+                Ok(Value::Float(unsafe { transmute::<[u8; 4], f32>(buf) }))
             }
-        },
-        Schema::TimestampMilli => match decode_long(reader)? {
-            Value::Long(millis) => {
-                let seconds = millis / 1_000;
-                let millis = (millis % 1_000) as u32;
-                Ok(Value::Timestamp(
-                    NaiveDateTime::from_timestamp_opt(seconds, millis * 1_000_000).ok_or_else(
-                        || DecodeError::new(format!("Invalid ms timestamp {}.{}", seconds, millis)),
-                    )?,
+            Schema::Double => {
+                let mut buf = [0u8; 8];
+                reader.read_exact(&mut buf[..]).await?;
+                Ok(Value::Double(unsafe { transmute::<[u8; 8], f64>(buf) }))
+            }
+            Schema::Date => match decode_int(reader).await? {
+                Value::Int(days) => Ok(Value::Date(
+                    NaiveDate::from_ymd(1970, 1, 1)
+                        .checked_add_signed(chrono::Duration::days(days.into()))
+                        .ok_or_else(|| {
+                            DecodeError::new(format!("Invalid num days from epoch: {0}", days))
+                        })?,
+                )),
+                other => Err(
+                    DecodeError::new(format!("Not an Int32 input for Date: {:?}", other)).into(),
+                ),
+            },
+            Schema::TimestampMilli => match decode_long(reader).await? {
+                Value::Long(millis) => {
+                    let seconds = millis / 1_000;
+                    let millis = (millis % 1_000) as u32;
+                    Ok(Value::Timestamp(
+                        NaiveDateTime::from_timestamp_opt(seconds, millis * 1_000_000).ok_or_else(
+                            || {
+                                DecodeError::new(format!(
+                                    "Invalid ms timestamp {}.{}",
+                                    seconds, millis
+                                ))
+                            },
+                        )?,
+                    ))
+                }
+                other => Err(DecodeError::new(format!(
+                    "Not an Int64 input for Millisecond DateTime: {:?}",
+                    other
                 ))
-            }
-            other => Err(DecodeError::new(format!(
-                "Not an Int64 input for Millisecond DateTime: {:?}",
-                other
-            ))
-            .into()),
-        },
-        Schema::TimestampMicro => match decode_long(reader)? {
-            Value::Long(micros) => {
-                let seconds = micros / 1_000_000;
-                let micros = (micros % 1_000_000) as u32;
-                Ok(Value::Timestamp(
-                    NaiveDateTime::from_timestamp_opt(seconds, micros * 1_000).ok_or_else(
-                        || DecodeError::new(format!("Invalid mu timestamp {}.{}", seconds, micros)),
-                    )?,
+                .into()),
+            },
+            Schema::TimestampMicro => match decode_long(reader).await? {
+                Value::Long(micros) => {
+                    let seconds = micros / 1_000_000;
+                    let micros = (micros % 1_000_000) as u32;
+                    Ok(Value::Timestamp(
+                        NaiveDateTime::from_timestamp_opt(seconds, micros * 1_000).ok_or_else(
+                            || {
+                                DecodeError::new(format!(
+                                    "Invalid mu timestamp {}.{}",
+                                    seconds, micros
+                                ))
+                            },
+                        )?,
+                    ))
+                }
+                other => Err(DecodeError::new(format!(
+                    "Not an Int64 input for Microsecond DateTime: {:?}",
+                    other
                 ))
-            }
-            other => Err(DecodeError::new(format!(
-                "Not an Int64 input for Microsecond DateTime: {:?}",
-                other
-            ))
-            .into()),
-        },
-        Schema::Decimal {
-            precision,
-            scale,
-            fixed_size,
-        } => {
-            let len = match fixed_size {
-                Some(len) => len,
-                None => decode_len(reader)?,
-            };
-            let mut buf = Vec::with_capacity(len);
-            unsafe {
-                buf.set_len(len);
-            }
-            reader.read_exact(&mut buf)?;
-            Ok(Value::Decimal {
-                unscaled: buf,
+                .into()),
+            },
+            Schema::Decimal {
                 precision,
                 scale,
-            })
-        }
-        Schema::Bytes => {
-            let len = decode_len(reader)?;
-            let mut buf = Vec::with_capacity(len);
-            unsafe {
-                buf.set_len(len);
-            }
-            reader.read_exact(&mut buf)?;
-            Ok(Value::Bytes(buf))
-        }
-        Schema::String => {
-            let len = decode_len(reader)?;
-            let mut buf = Vec::with_capacity(len);
-            unsafe {
-                buf.set_len(len);
-            }
-            reader.read_exact(&mut buf)?;
-
-            String::from_utf8(buf)
-                .map(Value::String)
-                .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
-        }
-        Schema::Fixed { size, .. } => {
-            let mut buf = vec![0u8; size as usize];
-            reader.read_exact(&mut buf)?;
-            Ok(Value::Fixed(size, buf))
-        }
-        Schema::Array(ref inner) => {
-            let mut items = Vec::new();
-
-            loop {
-                let len = decode_len(reader)?;
-                // arrays are 0-terminated, 0i64 is also encoded as 0 in Avro
-                // reading a length of 0 means the end of the array
-                if len == 0 {
-                    break;
+                fixed_size,
+            } => {
+                let len = match fixed_size {
+                    Some(len) => len,
+                    None => decode_len(reader).await?,
+                };
+                let mut buf = Vec::with_capacity(len);
+                unsafe {
+                    buf.set_len(len);
                 }
-
-                items.reserve(len as usize);
-                for _ in 0..len {
-                    items.push(decode(inner, reader)?);
-                }
+                reader.read_exact(&mut buf).await?;
+                Ok(Value::Decimal {
+                    unscaled: buf,
+                    precision,
+                    scale,
+                })
             }
-
-            Ok(Value::Array(items))
-        }
-        Schema::Map(ref inner) => {
-            let mut items = HashMap::new();
-
-            loop {
-                let len = decode_len(reader)?;
-                // maps are 0-terminated, 0i64 is also encoded as 0 in Avro
-                // reading a length of 0 means the end of the map
-                if len == 0 {
-                    break;
+            Schema::Bytes => {
+                let len = decode_len(reader).await?;
+                let mut buf = Vec::with_capacity(len);
+                unsafe {
+                    buf.set_len(len);
                 }
+                reader.read_exact(&mut buf).await?;
+                Ok(Value::Bytes(buf))
+            }
+            Schema::String => {
+                let len = decode_len(reader).await?;
+                let mut buf = Vec::with_capacity(len);
+                unsafe {
+                    buf.set_len(len);
+                }
+                reader.read_exact(&mut buf).await?;
 
-                items.reserve(len as usize);
-                for _ in 0..len {
-                    if let Value::String(key) = decode(&Schema::String, reader)? {
-                        let value = decode(inner, reader)?;
-                        items.insert(key, value);
-                    } else {
-                        return Err(DecodeError::new("map key is not a string").into());
+                String::from_utf8(buf)
+                    .map(Value::String)
+                    .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
+            }
+            Schema::Fixed { size, .. } => {
+                let mut buf = vec![0u8; size as usize];
+                reader.read_exact(&mut buf).await?;
+                Ok(Value::Fixed(size, buf))
+            }
+            Schema::Array(ref inner) => {
+                let mut items = Vec::new();
+
+                loop {
+                    let len = decode_len(reader).await?;
+                    // arrays are 0-terminated, 0i64 is also encoded as 0 in Avro
+                    // reading a length of 0 means the end of the array
+                    if len == 0 {
+                        break;
+                    }
+
+                    items.reserve(len as usize);
+                    for _ in 0..len {
+                        items.push(decode(inner, reader).await?);
                     }
                 }
-            }
 
-            Ok(Value::Map(items))
-        }
-        Schema::Union(ref inner) => {
-            let index = zag_i64(reader)?;
-            let variants = inner.variants();
-            match variants.get(index as usize) {
-                Some(variant) => decode(variant, reader).map(|x| Value::Union(Box::new(x))),
-                None => Err(DecodeError::new("Union index out of bounds").into()),
+                Ok(Value::Array(items))
             }
-        }
-        Schema::Record { ref fields, .. } => {
-            // Benchmarks indicate ~10% improvement using this method.
-            let mut items = Vec::new();
-            for field in fields {
-                // This clone is also expensive. See if we can do away with it...
-                items.push((field.name.clone(), decode(&field.schema, reader)?));
-            }
-            Ok(Value::Record(items))
-            // fields
-            // .iter()
-            // .map(|field| decode(&field.schema, reader).map(|value| (field.name.clone(), value)))
-            // .collect::<Result<Vec<(String, Value)>, _>>()
-            // .map(|items| Value::Record(items))
-        }
-        Schema::Enum { ref symbols, .. } => {
-            if let Value::Int(index) = decode_int(reader)? {
-                if index >= 0 && (index as usize) <= symbols.len() {
-                    let symbol = symbols[index as usize].clone();
-                    Ok(Value::Enum(index, symbol))
-                } else {
-                    Err(DecodeError::new("enum symbol index out of bounds").into())
+            Schema::Map(ref inner) => {
+                let mut items = HashMap::new();
+
+                loop {
+                    let len = decode_len(reader).await?;
+                    // maps are 0-terminated, 0i64 is also encoded as 0 in Avro
+                    // reading a length of 0 means the end of the map
+                    if len == 0 {
+                        break;
+                    }
+
+                    items.reserve(len as usize);
+                    for _ in 0..len {
+                        if let Value::String(key) = decode(&Schema::String, reader).await? {
+                            let value = decode(inner, reader).await?;
+                            items.insert(key, value);
+                        } else {
+                            return Err(DecodeError::new("map key is not a string").into());
+                        }
+                    }
                 }
-            } else {
-                Err(DecodeError::new("enum symbol not found").into())
+
+                Ok(Value::Map(items))
+            }
+            Schema::Union(ref inner) => {
+                let index = zag_i64(reader).await?;
+                let variants = inner.variants();
+                match variants.get(index as usize) {
+                    Some(variant) => decode(variant, reader)
+                        .await
+                        .map(|x| Value::Union(Box::new(x))),
+                    None => Err(DecodeError::new("Union index out of bounds").into()),
+                }
+            }
+            Schema::Record { ref fields, .. } => {
+                // Benchmarks indicate ~10% improvement using this method.
+                let mut items = Vec::new();
+                for field in fields {
+                    // This clone is also expensive. See if we can do away with it...
+                    items.push((field.name.clone(), decode(&field.schema, reader).await?));
+                }
+                Ok(Value::Record(items))
+                // fields
+                // .iter()
+                // .map(|field| decode(&field.schema, reader).map(|value| (field.name.clone(), value)))
+                // .collect::<Result<Vec<(String, Value)>, _>>()
+                // .map(|items| Value::Record(items))
+            }
+            Schema::Enum { ref symbols, .. } => {
+                if let Value::Int(index) = decode_int(reader).await? {
+                    if index >= 0 && (index as usize) <= symbols.len() {
+                        let symbol = symbols[index as usize].clone();
+                        Ok(Value::Enum(index, symbol))
+                    } else {
+                        Err(DecodeError::new("enum symbol index out of bounds").into())
+                    }
+                } else {
+                    Err(DecodeError::new("enum symbol not found").into())
+                }
             }
         }
     }
+    .boxed()
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -211,6 +211,7 @@ pub fn decode<'a, R: AsyncRead + Unpin + Send>(
             Schema::Record { ref fields, .. } => {
                 // Benchmarks indicate ~10% improvement using this method.
                 let mut items = Vec::new();
+                items.reserve(fields.len());
                 for field in fields {
                     // This clone is also expensive. See if we can do away with it...
                     items.push((field.name.clone(), decode(&field.schema, reader).await?));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,475 @@
+//! # avro-rs
+//! **[Apache Avro](https://avro.apache.org/)** is a data serialization system which provides rich
+//! data structures and a compact, fast, binary data format.
+//!
+//! All data in Avro is schematized, as in the following example:
+//!
+//! ```text
+//! {
+//!     "type": "record",
+//!     "name": "test",
+//!     "fields": [
+//!         {"name": "a", "type": "long", "default": 42},
+//!         {"name": "b", "type": "string"}
+//!     ]
+//! }
+//! ```
+//!
+//! There are basically two ways of handling Avro data in Rust:
+//!
+//! * **as Avro-specialized data types** based on an Avro schema;
+//! * **as generic Rust serde-compatible types** implementing/deriving `Serialize` and
+//! `Deserialize`;
+//!
+//! **avro-rs** provides a way to read and write both these data representations easily and
+//! efficiently.
+//!
+//! # Installing the library
+//!
+//!
+//! Add to your `Cargo.toml`:
+//!
+//! ```text
+//! [dependencies]
+//! avro-rs = "x.y"
+//! ```
+//!
+//! Or in case you want to leverage the **Snappy** codec:
+//!
+//! ```text
+//! [dependencies.avro-rs]
+//! version = "x.y"
+//! features = ["snappy"]
+//! ```
+//!
+//! # Defining a schema
+//!
+//! An Avro data cannot exist without an Avro schema. Schemas **must** be used while writing and
+//! **can** be used while reading and they carry the information regarding the type of data we are
+//! handling. Avro schemas are used for both schema validation and resolution of Avro data.
+//!
+//! Avro schemas are defined in **JSON** format and can just be parsed out of a raw string:
+//!
+//! ```
+//! use avro_rs::Schema;
+//!
+//! let raw_schema = r#"
+//!     {
+//!         "type": "record",
+//!         "name": "test",
+//!         "fields": [
+//!             {"name": "a", "type": "long", "default": 42},
+//!             {"name": "b", "type": "string"}
+//!         ]
+//!     }
+//! "#;
+//!
+//! // if the schema is not valid, this function will return an error
+//! let schema = Schema::parse_str(raw_schema).unwrap();
+//!
+//! // schemas can be printed for debugging
+//! println!("{:?}", schema);
+//! ```
+//!
+//! The library provides also a programmatic interface to define schemas without encoding them in
+//! JSON (for advanced use), but we highly recommend the JSON interface. Please read the API
+//! reference in case you are interested.
+//!
+//! For more information about schemas and what kind of information you can encapsulate in them,
+//! please refer to the appropriate section of the
+//! [Avro Specification](https://avro.apache.org/docs/current/spec.html#schemas).
+//!
+//! # Writing data
+//!
+//! Once we have defined a schema, we are ready to serialize data in Avro, validating them against
+//! the provided schema in the process. As mentioned before, there are two ways of handling Avro
+//! data in Rust.
+//!
+//! **NOTE:** The library also provides a low-level interface for encoding a single datum in Avro
+//! bytecode without generating markers and headers (for advanced use), but we highly recommend the
+//! `Writer` interface to be totally Avro-compatible. Please read the API reference in case you are
+//! interested.
+//!
+//! ## The avro way
+//!
+//! Given that the schema we defined above is that of an Avro *Record*, we are going to use the
+//! associated type provided by the library to specify the data we want to serialize:
+//!
+//! ```
+//! # use avro_rs::Schema;
+//! use avro_rs::types::Record;
+//! use avro_rs::Writer;
+//! #
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! // a writer needs a schema and something to write to
+//! let mut writer = Writer::new(&schema, Vec::new());
+//!
+//! // the Record type models our Record schema
+//! let mut record = Record::new(writer.schema()).unwrap();
+//! record.put("a", 27i64);
+//! record.put("b", "foo");
+//!
+//! // schema validation happens here
+//! writer.append(record).unwrap();
+//!
+//! // flushing makes sure that all data gets encoded
+//! writer.flush().unwrap();
+//!
+//! // this is how to get back the resulting avro bytecode
+//! let encoded = writer.into_inner();
+//! ```
+//!
+//! The vast majority of the times, schemas tend to define a record as a top-level container
+//! encapsulating all the values to convert as fields and providing documentation for them, but in
+//! case we want to directly define an Avro value, the library offers that capability via the
+//! `Value` interface.
+//!
+//! ```
+//! use avro_rs::types::Value;
+//!
+//! let mut value = Value::String("foo".to_string());
+//! ```
+//!
+//! ## The serde way
+//!
+//! Given that the schema we defined above is an Avro *Record*, we can directly use a Rust struct
+//! deriving `Serialize` to model our data:
+//!
+//! ```
+//! # use avro_rs::Schema;
+//! # use serde::Serialize;
+//! use avro_rs::Writer;
+//!
+//! #[derive(Debug, Serialize)]
+//! struct Test {
+//!     a: i64,
+//!     b: String,
+//! }
+//!
+//! # fn main() {
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! // a writer needs a schema and something to write to
+//! let mut writer = Writer::new(&schema, Vec::new());
+//!
+//! // the structure models our Record schema
+//! let test = Test {
+//!     a: 27,
+//!     b: "foo".to_owned(),
+//! };
+//!
+//! // schema validation happens here
+//! writer.append_ser(test).unwrap();
+//!
+//! // flushing makes sure that all data gets encoded
+//! writer.flush().unwrap();
+//!
+//! // this is how to get back the resulting avro bytecode
+//! let encoded = writer.into_inner();
+//! # }
+//! ```
+//!
+//! The vast majority of the times, schemas tend to define a record as a top-level container
+//! encapsulating all the values to convert as fields and providing documentation for them, but in
+//! case we want to directly define an Avro value, any type implementing `Serialize` should work.
+//!
+//! ```
+//! let mut value = "foo".to_string();
+//! ```
+//!
+//! ## Using codecs to compress data
+//!
+//! Avro supports three different compression codecs when encoding data:
+//!
+//! * **Null**: leaves data uncompressed;
+//! * **Deflate**: writes the data block using the deflate algorithm as specified in RFC 1951, and
+//! typically implemented using the zlib library. Note that this format (unlike the "zlib format" in
+//! RFC 1950) does not have a checksum.
+//! * **Snappy**: uses Google's [Snappy](http://google.github.io/snappy/) compression library. Each
+//! compressed block is followed by the 4-byte, big-endianCRC32 checksum of the uncompressed data in
+//! the block. You must enable the `snappy` feature to use this codec.
+//!
+//! To specify a codec to use to compress data, just specify it while creating a `Writer`:
+//! ```
+//! # use avro_rs::Schema;
+//! use avro_rs::Writer;
+//! use avro_rs::Codec;
+//! #
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
+//! ```
+//!
+//! # Reading data
+//!
+//! As far as reading Avro encoded data goes, we can just use the schema encoded with the data to
+//! read them. The library will do it automatically for us, as it already does for the compression
+//! codec:
+//!
+//! ```
+//!
+//! use avro_rs::Reader;
+//! # use avro_rs::Schema;
+//! # use avro_rs::types::Record;
+//! # use avro_rs::Writer;
+//! #
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let mut record = Record::new(writer.schema()).unwrap();
+//! # record.put("a", 27i64);
+//! # record.put("b", "foo");
+//! # writer.append(record).unwrap();
+//! # writer.flush().unwrap();
+//! # let input = writer.into_inner();
+//! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
+//! let reader = futures::executor::block_on(Reader::new(&input[..])).unwrap();
+//! ```
+//!
+//! In case, instead, we want to specify a different (but compatible) reader schema from the schema
+//! the data has been written with, we can just do as the following:
+//! ```
+//! use avro_rs::Schema;
+//! use avro_rs::Reader;
+//! # use avro_rs::types::Record;
+//! # use avro_rs::Writer;
+//! #
+//! # let writer_raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
+//! # let mut writer = Writer::new(&writer_schema, Vec::new());
+//! # let mut record = Record::new(writer.schema()).unwrap();
+//! # record.put("a", 27i64);
+//! # record.put("b", "foo");
+//! # writer.append(record).unwrap();
+//! # writer.flush().unwrap();
+//! # let input = writer.into_inner();
+//!
+//! let reader_raw_schema = r#"
+//!     {
+//!         "type": "record",
+//!         "name": "test",
+//!         "fields": [
+//!             {"name": "a", "type": "long", "default": 42},
+//!             {"name": "b", "type": "string"},
+//!             {"name": "c", "type": "long", "default": 43}
+//!         ]
+//!     }
+//! "#;
+//!
+//! let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
+//!
+//! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
+//! let reader = futures::executor::block_on(Reader::with_schema(&reader_schema, &input[..])).unwrap();
+//! ```
+//!
+//! The library will also automatically perform schema resolution while reading the data.
+//!
+//! For more information about schema compatibility and resolution, please refer to the
+//! [Avro Specification](https://avro.apache.org/docs/current/spec.html#schemas).
+//!
+//! As usual, there are two ways to handle Avro data in Rust, as you can see below.
+//!
+//! **NOTE:** The library also provides a low-level interface for decoding a single datum in Avro
+//! bytecode without markers and header (for advanced use), but we highly recommend the `Reader`
+//! interface to leverage all Avro features. Please read the API reference in case you are
+//! interested.
+//!
+//!
+//! ## The avro way
+//!
+//! We can just read directly instances of `Value` out of the `Reader` iterator:
+//!
+//! ```
+//! use futures::stream::StreamExt;
+//!
+//! # use avro_rs::Schema;
+//! # use avro_rs::types::Record;
+//! # use avro_rs::Writer;
+//! use avro_rs::Reader;
+//! #
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let mut record = Record::new(writer.schema()).unwrap();
+//! # record.put("a", 27i64);
+//! # record.put("b", "foo");
+//! # writer.append(record).unwrap();
+//! # writer.flush().unwrap();
+//! # let input = writer.into_inner();
+//! let mut reader = futures::executor::block_on(Reader::new(&input[..])).unwrap().into_stream();
+//!
+//! // value is a Result  of an Avro Value in case the read operation fails
+//! while let Some(value) = futures::executor::block_on(reader.next()) {
+//!     println!("{:?}", value.unwrap());
+//! }
+//!
+//! ```
+//!
+//! ## The serde way
+//!
+//! Alternatively, we can use a Rust type implementing `Deserialize` and representing our schema to
+//! read the data into:
+//!
+//! ```
+//! use futures::stream::StreamExt;
+//! # use avro_rs::Schema;
+//! # use avro_rs::Writer;
+//! # use serde::{Deserialize, Serialize};
+//! use avro_rs::Reader;
+//! use avro_rs::from_value;
+//!
+//! # #[derive(Serialize)]
+//! #[derive(Debug, Deserialize)]
+//! struct Test {
+//!     a: i64,
+//!     b: String,
+//! }
+//!
+//! # fn main() {
+//! # let raw_schema = r#"
+//! #     {
+//! #         "type": "record",
+//! #         "name": "test",
+//! #         "fields": [
+//! #             {"name": "a", "type": "long", "default": 42},
+//! #             {"name": "b", "type": "string"}
+//! #         ]
+//! #     }
+//! # "#;
+//! # let schema = Schema::parse_str(raw_schema).unwrap();
+//! # let mut writer = Writer::new(&schema, Vec::new());
+//! # let test = Test {
+//! #     a: 27,
+//! #     b: "foo".to_owned(),
+//! # };
+//! # writer.append_ser(test).unwrap();
+//! # writer.flush().unwrap();
+//! # let input = writer.into_inner();
+//! let mut reader = futures::executor::block_on(Reader::new(&input[..])).unwrap().into_stream();
+//!
+//! // value is a Result in case the read operation fails
+//! while let Some(value) = futures::executor::block_on(reader.next()) {
+//!     println!("{:?}", from_value::<Test>(&value.unwrap()));
+//! }
+//! # }
+//! ```
+//!
+//! # Putting everything together
+//!
+//! The following is an example of how to combine everything showed so far and it is meant to be a
+//! quick reference of the library interface:
+//!
+//! ```
+//! use futures::stream::StreamExt;
+//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
+//! use failure::Error;
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Deserialize, Serialize)]
+//! struct Test {
+//!     a: i64,
+//!     b: String,
+//! }
+//!
+//! fn main() -> Result<(), Error> {
+//!     let raw_schema = r#"
+//!         {
+//!             "type": "record",
+//!             "name": "test",
+//!             "fields": [
+//!                 {"name": "a", "type": "long", "default": 42},
+//!                 {"name": "b", "type": "string"}
+//!             ]
+//!         }
+//!     "#;
+//!
+//!     let schema = Schema::parse_str(raw_schema)?;
+//!
+//!     println!("{:?}", schema);
+//!
+//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
+//!
+//!     let mut record = Record::new(writer.schema()).unwrap();
+//!     record.put("a", 27i64);
+//!     record.put("b", "foo");
+//!
+//!     writer.append(record)?;
+//!
+//!     let test = Test {
+//!         a: 27,
+//!         b: "foo".to_owned(),
+//!     };
+//!
+//!     writer.append_ser(test)?;
+//!
+//!     writer.flush()?;
+//!
+//!     let input = writer.into_inner();
+//!     let mut reader = futures::executor::block_on(Reader::with_schema(&schema, &input[..]))?.into_stream();
+//!
+//!     while let Some(value) = futures::executor::block_on(reader.next()) {
+//!         println!("{:?}", from_value::<Test>(&value?));
+//!     }
+//!     Ok(())
+//! }
+//! ```
+
 mod codec;
 mod de;
 mod decode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,470 +1,3 @@
-//! # avro-rs
-//! **[Apache Avro](https://avro.apache.org/)** is a data serialization system which provides rich
-//! data structures and a compact, fast, binary data format.
-//!
-//! All data in Avro is schematized, as in the following example:
-//!
-//! ```text
-//! {
-//!     "type": "record",
-//!     "name": "test",
-//!     "fields": [
-//!         {"name": "a", "type": "long", "default": 42},
-//!         {"name": "b", "type": "string"}
-//!     ]
-//! }
-//! ```
-//!
-//! There are basically two ways of handling Avro data in Rust:
-//!
-//! * **as Avro-specialized data types** based on an Avro schema;
-//! * **as generic Rust serde-compatible types** implementing/deriving `Serialize` and
-//! `Deserialize`;
-//!
-//! **avro-rs** provides a way to read and write both these data representations easily and
-//! efficiently.
-//!
-//! # Installing the library
-//!
-//!
-//! Add to your `Cargo.toml`:
-//!
-//! ```text
-//! [dependencies]
-//! avro-rs = "x.y"
-//! ```
-//!
-//! Or in case you want to leverage the **Snappy** codec:
-//!
-//! ```text
-//! [dependencies.avro-rs]
-//! version = "x.y"
-//! features = ["snappy"]
-//! ```
-//!
-//! # Defining a schema
-//!
-//! An Avro data cannot exist without an Avro schema. Schemas **must** be used while writing and
-//! **can** be used while reading and they carry the information regarding the type of data we are
-//! handling. Avro schemas are used for both schema validation and resolution of Avro data.
-//!
-//! Avro schemas are defined in **JSON** format and can just be parsed out of a raw string:
-//!
-//! ```
-//! use avro_rs::Schema;
-//!
-//! let raw_schema = r#"
-//!     {
-//!         "type": "record",
-//!         "name": "test",
-//!         "fields": [
-//!             {"name": "a", "type": "long", "default": 42},
-//!             {"name": "b", "type": "string"}
-//!         ]
-//!     }
-//! "#;
-//!
-//! // if the schema is not valid, this function will return an error
-//! let schema = Schema::parse_str(raw_schema).unwrap();
-//!
-//! // schemas can be printed for debugging
-//! println!("{:?}", schema);
-//! ```
-//!
-//! The library provides also a programmatic interface to define schemas without encoding them in
-//! JSON (for advanced use), but we highly recommend the JSON interface. Please read the API
-//! reference in case you are interested.
-//!
-//! For more information about schemas and what kind of information you can encapsulate in them,
-//! please refer to the appropriate section of the
-//! [Avro Specification](https://avro.apache.org/docs/current/spec.html#schemas).
-//!
-//! # Writing data
-//!
-//! Once we have defined a schema, we are ready to serialize data in Avro, validating them against
-//! the provided schema in the process. As mentioned before, there are two ways of handling Avro
-//! data in Rust.
-//!
-//! **NOTE:** The library also provides a low-level interface for encoding a single datum in Avro
-//! bytecode without generating markers and headers (for advanced use), but we highly recommend the
-//! `Writer` interface to be totally Avro-compatible. Please read the API reference in case you are
-//! interested.
-//!
-//! ## The avro way
-//!
-//! Given that the schema we defined above is that of an Avro *Record*, we are going to use the
-//! associated type provided by the library to specify the data we want to serialize:
-//!
-//! ```
-//! # use avro_rs::Schema;
-//! use avro_rs::types::Record;
-//! use avro_rs::Writer;
-//! #
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! // a writer needs a schema and something to write to
-//! let mut writer = Writer::new(&schema, Vec::new());
-//!
-//! // the Record type models our Record schema
-//! let mut record = Record::new(writer.schema()).unwrap();
-//! record.put("a", 27i64);
-//! record.put("b", "foo");
-//!
-//! // schema validation happens here
-//! writer.append(record).unwrap();
-//!
-//! // flushing makes sure that all data gets encoded
-//! writer.flush().unwrap();
-//!
-//! // this is how to get back the resulting avro bytecode
-//! let encoded = writer.into_inner();
-//! ```
-//!
-//! The vast majority of the times, schemas tend to define a record as a top-level container
-//! encapsulating all the values to convert as fields and providing documentation for them, but in
-//! case we want to directly define an Avro value, the library offers that capability via the
-//! `Value` interface.
-//!
-//! ```
-//! use avro_rs::types::Value;
-//!
-//! let mut value = Value::String("foo".to_string());
-//! ```
-//!
-//! ## The serde way
-//!
-//! Given that the schema we defined above is an Avro *Record*, we can directly use a Rust struct
-//! deriving `Serialize` to model our data:
-//!
-//! ```
-//! # use avro_rs::Schema;
-//! # use serde::Serialize;
-//! use avro_rs::Writer;
-//!
-//! #[derive(Debug, Serialize)]
-//! struct Test {
-//!     a: i64,
-//!     b: String,
-//! }
-//!
-//! # fn main() {
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! // a writer needs a schema and something to write to
-//! let mut writer = Writer::new(&schema, Vec::new());
-//!
-//! // the structure models our Record schema
-//! let test = Test {
-//!     a: 27,
-//!     b: "foo".to_owned(),
-//! };
-//!
-//! // schema validation happens here
-//! writer.append_ser(test).unwrap();
-//!
-//! // flushing makes sure that all data gets encoded
-//! writer.flush().unwrap();
-//!
-//! // this is how to get back the resulting avro bytecode
-//! let encoded = writer.into_inner();
-//! # }
-//! ```
-//!
-//! The vast majority of the times, schemas tend to define a record as a top-level container
-//! encapsulating all the values to convert as fields and providing documentation for them, but in
-//! case we want to directly define an Avro value, any type implementing `Serialize` should work.
-//!
-//! ```
-//! let mut value = "foo".to_string();
-//! ```
-//!
-//! ## Using codecs to compress data
-//!
-//! Avro supports three different compression codecs when encoding data:
-//!
-//! * **Null**: leaves data uncompressed;
-//! * **Deflate**: writes the data block using the deflate algorithm as specified in RFC 1951, and
-//! typically implemented using the zlib library. Note that this format (unlike the "zlib format" in
-//! RFC 1950) does not have a checksum.
-//! * **Snappy**: uses Google's [Snappy](http://google.github.io/snappy/) compression library. Each
-//! compressed block is followed by the 4-byte, big-endianCRC32 checksum of the uncompressed data in
-//! the block. You must enable the `snappy` feature to use this codec.
-//!
-//! To specify a codec to use to compress data, just specify it while creating a `Writer`:
-//! ```
-//! # use avro_rs::Schema;
-//! use avro_rs::Writer;
-//! use avro_rs::Codec;
-//! #
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
-//! ```
-//!
-//! # Reading data
-//!
-//! As far as reading Avro encoded data goes, we can just use the schema encoded with the data to
-//! read them. The library will do it automatically for us, as it already does for the compression
-//! codec:
-//!
-//! ```
-//! use avro_rs::Reader;
-//! # use avro_rs::Schema;
-//! # use avro_rs::types::Record;
-//! # use avro_rs::Writer;
-//! #
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
-//! # let mut record = Record::new(writer.schema()).unwrap();
-//! # record.put("a", 27i64);
-//! # record.put("b", "foo");
-//! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
-//! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
-//! let reader = Reader::new(&input[..]).unwrap();
-//! ```
-//!
-//! In case, instead, we want to specify a different (but compatible) reader schema from the schema
-//! the data has been written with, we can just do as the following:
-//! ```
-//! use avro_rs::Schema;
-//! use avro_rs::Reader;
-//! # use avro_rs::types::Record;
-//! # use avro_rs::Writer;
-//! #
-//! # let writer_raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let writer_schema = Schema::parse_str(writer_raw_schema).unwrap();
-//! # let mut writer = Writer::new(&writer_schema, Vec::new());
-//! # let mut record = Record::new(writer.schema()).unwrap();
-//! # record.put("a", 27i64);
-//! # record.put("b", "foo");
-//! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
-//!
-//! let reader_raw_schema = r#"
-//!     {
-//!         "type": "record",
-//!         "name": "test",
-//!         "fields": [
-//!             {"name": "a", "type": "long", "default": 42},
-//!             {"name": "b", "type": "string"},
-//!             {"name": "c", "type": "long", "default": 43}
-//!         ]
-//!     }
-//! "#;
-//!
-//! let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
-//!
-//! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
-//! let reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-//! ```
-//!
-//! The library will also automatically perform schema resolution while reading the data.
-//!
-//! For more information about schema compatibility and resolution, please refer to the
-//! [Avro Specification](https://avro.apache.org/docs/current/spec.html#schemas).
-//!
-//! As usual, there are two ways to handle Avro data in Rust, as you can see below.
-//!
-//! **NOTE:** The library also provides a low-level interface for decoding a single datum in Avro
-//! bytecode without markers and header (for advanced use), but we highly recommend the `Reader`
-//! interface to leverage all Avro features. Please read the API reference in case you are
-//! interested.
-//!
-//!
-//! ## The avro way
-//!
-//! We can just read directly instances of `Value` out of the `Reader` iterator:
-//!
-//! ```
-//! # use avro_rs::Schema;
-//! # use avro_rs::types::Record;
-//! # use avro_rs::Writer;
-//! use avro_rs::Reader;
-//! #
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
-//! # let mut record = Record::new(writer.schema()).unwrap();
-//! # record.put("a", 27i64);
-//! # record.put("b", "foo");
-//! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
-//! let reader = Reader::new(&input[..]).unwrap();
-//!
-//! // value is a Result  of an Avro Value in case the read operation fails
-//! for value in reader {
-//!     println!("{:?}", value.unwrap());
-//! }
-//!
-//! ```
-//!
-//! ## The serde way
-//!
-//! Alternatively, we can use a Rust type implementing `Deserialize` and representing our schema to
-//! read the data into:
-//!
-//! ```
-//! # use avro_rs::Schema;
-//! # use avro_rs::Writer;
-//! # use serde::{Deserialize, Serialize};
-//! use avro_rs::Reader;
-//! use avro_rs::from_value;
-//!
-//! # #[derive(Serialize)]
-//! #[derive(Debug, Deserialize)]
-//! struct Test {
-//!     a: i64,
-//!     b: String,
-//! }
-//!
-//! # fn main() {
-//! # let raw_schema = r#"
-//! #     {
-//! #         "type": "record",
-//! #         "name": "test",
-//! #         "fields": [
-//! #             {"name": "a", "type": "long", "default": 42},
-//! #             {"name": "b", "type": "string"}
-//! #         ]
-//! #     }
-//! # "#;
-//! # let schema = Schema::parse_str(raw_schema).unwrap();
-//! # let mut writer = Writer::new(&schema, Vec::new());
-//! # let test = Test {
-//! #     a: 27,
-//! #     b: "foo".to_owned(),
-//! # };
-//! # writer.append_ser(test).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
-//! let reader = Reader::new(&input[..]).unwrap();
-//!
-//! // value is a Result in case the read operation fails
-//! for value in reader {
-//!     println!("{:?}", from_value::<Test>(&value.unwrap()));
-//! }
-//! # }
-//! ```
-//!
-//! # Putting everything together
-//!
-//! The following is an example of how to combine everything showed so far and it is meant to be a
-//! quick reference of the library interface:
-//!
-//! ```
-//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
-//! use failure::Error;
-//! use serde::{Deserialize, Serialize};
-//!
-//! #[derive(Debug, Deserialize, Serialize)]
-//! struct Test {
-//!     a: i64,
-//!     b: String,
-//! }
-//!
-//! fn main() -> Result<(), Error> {
-//!     let raw_schema = r#"
-//!         {
-//!             "type": "record",
-//!             "name": "test",
-//!             "fields": [
-//!                 {"name": "a", "type": "long", "default": 42},
-//!                 {"name": "b", "type": "string"}
-//!             ]
-//!         }
-//!     "#;
-//!
-//!     let schema = Schema::parse_str(raw_schema)?;
-//!
-//!     println!("{:?}", schema);
-//!
-//!     let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Deflate);
-//!
-//!     let mut record = Record::new(writer.schema()).unwrap();
-//!     record.put("a", 27i64);
-//!     record.put("b", "foo");
-//!
-//!     writer.append(record)?;
-//!
-//!     let test = Test {
-//!         a: 27,
-//!         b: "foo".to_owned(),
-//!     };
-//!
-//!     writer.append_ser(test)?;
-//!
-//!     writer.flush()?;
-//!
-//!     let input = writer.into_inner();
-//!     let reader = Reader::with_schema(&schema, &input[..])?;
-//!
-//!     for record in reader {
-//!         println!("{:?}", from_value::<Test>(&record?));
-//!     }
-//!     Ok(())
-//! }
-//! ```
-
 mod codec;
 mod de;
 mod decode;
@@ -492,6 +25,8 @@ mod tests {
     use crate::reader::Reader;
     use crate::schema::Schema;
     use crate::types::{Record, Value};
+
+    use futures::executor::block_on;
 
     //TODO: move where it fits better
     #[test]
@@ -534,16 +69,16 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
+        let mut reader = block_on(Reader::with_schema(&reader_schema, &input[..])).unwrap();
         assert_eq!(
-            reader.next().unwrap().unwrap(),
+            block_on(reader.read_next()).unwrap().unwrap(),
             Value::Record(vec![
                 ("a".to_string(), Value::Long(27)),
                 ("b".to_string(), Value::String("foo".to_string())),
                 ("c".to_string(), Value::Enum(1, "spades".to_string())),
             ])
         );
-        assert!(reader.next().is_none());
+        assert!(block_on(reader.read_next()).unwrap().is_none());
     }
 
     //TODO: move where it fits better
@@ -577,16 +112,16 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&schema, &input[..]).unwrap();
+        let mut reader = block_on(Reader::with_schema(&schema, &input[..])).unwrap();
         assert_eq!(
-            reader.next().unwrap().unwrap(),
+            block_on(reader.read_next()).unwrap().unwrap(),
             Value::Record(vec![
                 ("a".to_string(), Value::Long(27)),
                 ("b".to_string(), Value::String("foo".to_string())),
                 ("c".to_string(), Value::Enum(2, "clubs".to_string())),
             ])
         );
-        assert!(reader.next().is_none());
+        assert!(block_on(reader.read_next()).unwrap().is_none());
     }
 
     //TODO: move where it fits better
@@ -640,9 +175,9 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
-        assert!(reader.next().unwrap().is_err());
-        assert!(reader.next().is_none());
+        let mut reader = block_on(Reader::with_schema(&reader_schema, &input[..])).unwrap();
+        assert!(block_on(reader.read_next()).is_err());
+        assert!(block_on(reader.read_next()).unwrap().is_none());
     }
 
     //TODO: move where it fits better
@@ -676,9 +211,9 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::new(&input[..]).unwrap();
+        let mut reader = block_on(Reader::new(&input[..])).unwrap();
         assert_eq!(
-            reader.next().unwrap().unwrap(),
+            block_on(reader.read_next()).unwrap().unwrap(),
             Value::Record(vec![
                 ("a".to_string(), Value::Long(27)),
                 ("b".to_string(), Value::String("foo".to_string())),
@@ -708,9 +243,9 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::new(&input[..]).unwrap();
+        let mut reader = block_on(Reader::new(&input[..])).unwrap();
         assert_eq!(
-            reader.next().unwrap().unwrap(),
+            block_on(reader.read_next()).unwrap().unwrap(),
             Value::Record(vec![("a".to_string(), Value::Timestamp(dt)),])
         );
     }
@@ -733,7 +268,7 @@ mod tests {
         // Would allocated 18446744073709551605 bytes
         let illformed: &[u8] = &[0x3e, 0x15, 0xff, 0x1f, 0x15, 0xff];
 
-        let value = from_avro_datum(&schema, &mut &illformed[..], None);
+        let value = block_on(from_avro_datum(&schema, &mut &illformed[..], None));
         assert!(value.is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,10 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).await.unwrap().into_stream();
+        let mut reader = Reader::with_schema(&reader_schema, &input[..])
+            .await
+            .unwrap()
+            .into_stream();
         assert_eq!(
             reader.next().await.unwrap().unwrap(),
             Value::Record(vec![
@@ -112,7 +115,10 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&schema, &input[..]).await.unwrap().into_stream();
+        let mut reader = Reader::with_schema(&schema, &input[..])
+            .await
+            .unwrap()
+            .into_stream();
         assert_eq!(
             reader.next().await.unwrap().unwrap(),
             Value::Record(vec![
@@ -175,7 +181,10 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]).await.unwrap().into_stream();
+        let mut reader = Reader::with_schema(&reader_schema, &input[..])
+            .await
+            .unwrap()
+            .into_stream();
         assert!(reader.next().await.unwrap().is_err());
         assert!(reader.next().await.is_none());
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1311,5 +1311,4 @@ mod tests {
             format!("{}", schema.fingerprint::<Md5>())
         );
     }
-
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -157,6 +157,7 @@ pub fn safe_len(len: usize) -> Result<usize, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::executor::block_on;
 
     #[test]
     fn test_zigzag() {
@@ -221,10 +222,10 @@ mod tests {
         assert_eq!(s, [255, 255, 255, 255, 15]);
     }
 
-    #[test]
-    fn test_overflow() {
+    #[tokio::test]
+    async fn test_overflow() {
         let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
-        assert!(block_on(decode_variable(&mut &causes_left_shift_overflow[..])).is_err());
+        assert!(decode_variable(&mut &causes_left_shift_overflow[..]).await.is_err());
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 use std::i64;
-use std::io::Read;
 use std::sync::{Once, ONCE_INIT};
 
 use failure::{Error, Fail};
 use serde_json::{Map, Value};
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 /// Maximum number of bytes that can be allocated when decoding
 /// Avro-encoded values. This is a protection against ill-formed
@@ -60,8 +60,8 @@ impl MapHelper for Map<String, Value> {
     }
 }
 
-pub fn read_long<R: Read>(reader: &mut R) -> Result<i64, Error> {
-    zag_i64(reader)
+pub async fn read_long<R: AsyncRead + Unpin>(reader: &mut R) -> Result<i64, Error> {
+    zag_i64(reader).await
 }
 
 pub fn zig_i32(n: i32, buffer: &mut Vec<u8>) {
@@ -72,8 +72,8 @@ pub fn zig_i64(n: i64, buffer: &mut Vec<u8>) {
     encode_variable(((n << 1) ^ (n >> 63)) as u64, buffer)
 }
 
-pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, Error> {
-    let i = zag_i64(reader)?;
+pub async fn zag_i32<R: AsyncRead + Unpin>(reader: &mut R) -> Result<i32, Error> {
+    let i = zag_i64(reader).await?;
     if i < i64::from(i32::min_value()) || i > i64::from(i32::max_value()) {
         Err(DecodeError::new("int out of range").into())
     } else {
@@ -81,8 +81,8 @@ pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, Error> {
     }
 }
 
-pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, Error> {
-    let z = decode_variable(reader)?;
+pub async fn zag_i64<R: AsyncRead + Unpin>(reader: &mut R) -> Result<i64, Error> {
+    let z = decode_variable(reader).await?;
     Ok(if z & 0x1 == 0 {
         (z >> 1) as i64
     } else {
@@ -102,7 +102,7 @@ fn encode_variable(mut z: u64, buffer: &mut Vec<u8>) {
     }
 }
 
-fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
+async fn decode_variable<R: AsyncRead + Unpin>(reader: &mut R) -> Result<u64, Error> {
     let mut i = 0u64;
     let mut buf = [0u8; 1];
 
@@ -112,7 +112,7 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
             // if j * 7 > 64
             return Err(DecodeError::new("Overflow when decoding integer value").into());
         }
-        reader.read_exact(&mut buf[..])?;
+        reader.read_exact(&mut buf[..]).await?;
         i |= (u64::from(buf[0] & 0x7F)) << (j * 7);
         if (buf[0] >> 7) == 0 {
             break;

--- a/src/util.rs
+++ b/src/util.rs
@@ -225,7 +225,9 @@ mod tests {
     #[tokio::test]
     async fn test_overflow() {
         let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
-        assert!(decode_variable(&mut &causes_left_shift_overflow[..]).await.is_err());
+        assert!(decode_variable(&mut &causes_left_shift_overflow[..])
+            .await
+            .is_err());
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn test_overflow() {
         let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
-        assert!(decode_variable(&mut &causes_left_shift_overflow[..]).is_err());
+        assert!(block_on(decode_variable(&mut &causes_left_shift_overflow[..])).is_err());
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -157,7 +157,6 @@ pub fn safe_len(len: usize) -> Result<usize, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::executor::block_on;
 
     #[test]
     fn test_zigzag() {

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -96,7 +96,9 @@ async fn test_round_trip() {
     for (raw_schema, value) in SCHEMAS_TO_VALIDATE.iter() {
         let schema = Schema::parse_str(raw_schema).unwrap();
         let encoded = to_avro_datum(&schema, value.clone()).unwrap();
-        let decoded = from_avro_datum(&schema, &mut Cursor::new(encoded), None).await.unwrap();
+        let decoded = from_avro_datum(&schema, &mut Cursor::new(encoded), None)
+            .await
+            .unwrap();
         assert_eq!(value, &decoded);
     }
 }
@@ -138,7 +140,8 @@ async fn test_schema_promotion() {
                 &writer_schema,
                 &mut Cursor::new(encoded),
                 Some(&reader_schema),
-            ).await
+            )
+            .await
             .expect(&format!(
                 "failed to decode {:?} with schema: {:?}",
                 original_value, reader_raw_schema
@@ -162,7 +165,8 @@ async fn test_unknown_symbol() {
         &writer_schema,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ).await;
+    )
+    .await;
     assert!(decoded.is_err());
 }
 
@@ -186,7 +190,8 @@ async fn test_default_value() {
             &LONG_RECORD_SCHEMA,
             &mut Cursor::new(encoded),
             Some(&reader_schema),
-        ).await
+        )
+        .await
         .unwrap();
         assert_eq!(
             datum_read, datum_to_read,
@@ -213,7 +218,8 @@ async fn test_no_default_value() -> Result<(), String> {
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ).await;
+    )
+    .await;
     match decoded {
         Ok(_) => Err(String::from("Expected SchemaResolutionError, got Ok")),
         Err(ref e) => match e.downcast_ref::<SchemaResolutionError>() {
@@ -247,7 +253,8 @@ async fn test_projection() {
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ).await
+    )
+    .await
     .unwrap();
     assert_eq!(datum_to_read, datum_read);
 }
@@ -276,7 +283,8 @@ async fn test_field_order() {
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ).await
+    )
+    .await
     .unwrap();
     assert_eq!(datum_to_read, datum_read);
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -4,7 +4,6 @@ use std::io::Cursor;
 use avro_rs::{
     from_avro_datum, to_avro_datum, types::Value, Schema, SchemaResolutionError, ValidationError,
 };
-use futures::executor::block_on;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -92,12 +91,12 @@ fn test_validate() {
     }
 }
 
-#[test]
-fn test_round_trip() {
+#[tokio::test]
+async fn test_round_trip() {
     for (raw_schema, value) in SCHEMAS_TO_VALIDATE.iter() {
         let schema = Schema::parse_str(raw_schema).unwrap();
         let encoded = to_avro_datum(&schema, value.clone()).unwrap();
-        let decoded = block_on(from_avro_datum(&schema, &mut Cursor::new(encoded), None)).unwrap();
+        let decoded = from_avro_datum(&schema, &mut Cursor::new(encoded), None).await.unwrap();
         assert_eq!(value, &decoded);
     }
 }
@@ -118,8 +117,8 @@ fn test_binary_long_encoding() {
     }
 }
 
-#[test]
-fn test_schema_promotion() {
+#[tokio::test]
+async fn test_schema_promotion() {
     // Each schema is present in order of promotion (int -> long, long -> float, float -> double)
     // Each value represents the expected decoded value when promoting a value previously encoded with a promotable schema
     let promotable_schemas = vec![r#""int""#, r#""long""#, r#""float""#, r#""double""#];
@@ -135,11 +134,11 @@ fn test_schema_promotion() {
         for (j, reader_raw_schema) in promotable_schemas.iter().enumerate().skip(i + 1) {
             let reader_schema = Schema::parse_str(reader_raw_schema).unwrap();
             let encoded = to_avro_datum(&writer_schema, original_value.clone()).unwrap();
-            let decoded = block_on(from_avro_datum(
+            let decoded = from_avro_datum(
                 &writer_schema,
                 &mut Cursor::new(encoded),
                 Some(&reader_schema),
-            ))
+            ).await
             .expect(&format!(
                 "failed to decode {:?} with schema: {:?}",
                 original_value, reader_raw_schema
@@ -149,8 +148,8 @@ fn test_schema_promotion() {
     }
 }
 
-#[test]
-fn test_unknown_symbol() {
+#[tokio::test]
+async fn test_unknown_symbol() {
     let writer_schema =
         Schema::parse_str(r#"{"type": "enum", "name": "Test", "symbols": ["FOO", "BAR"]}"#)
             .unwrap();
@@ -159,16 +158,16 @@ fn test_unknown_symbol() {
             .unwrap();
     let original_value = Value::Enum(0, "FOO".to_string());
     let encoded = to_avro_datum(&writer_schema, original_value).unwrap();
-    let decoded = block_on(from_avro_datum(
+    let decoded = from_avro_datum(
         &writer_schema,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ));
+    ).await;
     assert!(decoded.is_err());
 }
 
-#[test]
-fn test_default_value() {
+#[tokio::test]
+async fn test_default_value() {
     for (field_type, default_json, default_datum) in DEFAULT_VALUE_EXAMPLES.iter() {
         let reader_schema = Schema::parse_str(&format!(
             r#"{{
@@ -183,11 +182,11 @@ fn test_default_value() {
         .unwrap();
         let datum_to_read = Value::Record(vec![("H".to_string(), default_datum.clone())]);
         let encoded = to_avro_datum(&LONG_RECORD_SCHEMA, LONG_RECORD_DATUM.clone()).unwrap();
-        let datum_read = block_on(from_avro_datum(
+        let datum_read = from_avro_datum(
             &LONG_RECORD_SCHEMA,
             &mut Cursor::new(encoded),
             Some(&reader_schema),
-        ))
+        ).await
         .unwrap();
         assert_eq!(
             datum_read, datum_to_read,
@@ -197,8 +196,8 @@ fn test_default_value() {
     }
 }
 
-#[test]
-fn test_no_default_value() -> Result<(), String> {
+#[tokio::test]
+async fn test_no_default_value() -> Result<(), String> {
     let reader_schema = Schema::parse_str(
         r#"{
             "type": "record",
@@ -210,11 +209,11 @@ fn test_no_default_value() -> Result<(), String> {
     )
     .unwrap();
     let encoded = to_avro_datum(&LONG_RECORD_SCHEMA, LONG_RECORD_DATUM.clone()).unwrap();
-    let decoded = block_on(from_avro_datum(
+    let decoded = from_avro_datum(
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ));
+    ).await;
     match decoded {
         Ok(_) => Err(String::from("Expected SchemaResolutionError, got Ok")),
         Err(ref e) => match e.downcast_ref::<SchemaResolutionError>() {
@@ -224,8 +223,8 @@ fn test_no_default_value() -> Result<(), String> {
     }
 }
 
-#[test]
-fn test_projection() {
+#[tokio::test]
+async fn test_projection() {
     let reader_schema = Schema::parse_str(
         r#"
         {
@@ -244,17 +243,17 @@ fn test_projection() {
         ("F".to_string(), Value::Int(6)),
     ]);
     let encoded = to_avro_datum(&LONG_RECORD_SCHEMA, LONG_RECORD_DATUM.clone()).unwrap();
-    let datum_read = block_on(from_avro_datum(
+    let datum_read = from_avro_datum(
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ))
+    ).await
     .unwrap();
     assert_eq!(datum_to_read, datum_read);
 }
 
-#[test]
-fn test_field_order() {
+#[tokio::test]
+async fn test_field_order() {
     let reader_schema = Schema::parse_str(
         r#"
         {
@@ -273,11 +272,11 @@ fn test_field_order() {
         ("E".to_string(), Value::Int(5)),
     ]);
     let encoded = to_avro_datum(&LONG_RECORD_SCHEMA, LONG_RECORD_DATUM.clone()).unwrap();
-    let datum_read = block_on(from_avro_datum(
+    let datum_read = from_avro_datum(
         &LONG_RECORD_SCHEMA,
         &mut Cursor::new(encoded),
         Some(&reader_schema),
-    ))
+    ).await
     .unwrap();
     assert_eq!(datum_to_read, datum_read);
 }


### PR DESCRIPTION
Materialize isn't (yet!) using the Reader API, so after this lands, we can use it *almost* as-is without any changes.

One small change is needed in materialize before this is used there -- to wrap calls to `from_avro_datum` in `futures::executor::block_on`. I have verified that all tests in Materialize still pass with this change.